### PR TITLE
fix: simple warnings shown on pub.dev

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -28,28 +28,21 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -63,7 +56,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -80,21 +73,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   nested:
     dependency: transitive
     description:
@@ -108,7 +101,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   provider:
     dependency: transitive
     description:
@@ -127,7 +120,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -148,35 +141,28 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.12"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=1.16.0"

--- a/lib/src/cell_calendar.dart
+++ b/lib/src/cell_calendar.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -11,9 +10,9 @@ import 'controllers/cell_calendar_page_controller.dart';
 import 'controllers/cell_height_controller.dart';
 import 'date_extension.dart';
 
-typedef daysBuilder = Widget Function(int dayIndex);
+typedef DaysBuilder = Widget Function(int dayIndex);
 
-typedef monthYearBuilder = Widget Function(DateTime? visibleDateTime);
+typedef MonthYearBuilder = Widget Function(DateTime? visibleDateTime);
 
 class TodayUIConfig {
   final Color todayMarkColor;
@@ -44,9 +43,9 @@ class CellCalendar extends StatelessWidget {
   ///
   /// 0 for Sunday, 6 for Saturday.
   /// By default, it returns English labels
-  final daysBuilder? daysOfTheWeekBuilder;
+  final DaysBuilder? daysOfTheWeekBuilder;
 
-  final monthYearBuilder? monthYearLabelBuilder;
+  final MonthYearBuilder? monthYearLabelBuilder;
 
   final TextStyle? dateTextStyle;
 
@@ -91,8 +90,8 @@ class _CalendarPageView extends StatelessWidget {
     this.cellCalendarPageController,
   );
 
-  final daysBuilder? daysOfTheWeekBuilder;
-  final monthYearBuilder? monthYearLabelBuilder;
+  final DaysBuilder? daysOfTheWeekBuilder;
+  final MonthYearBuilder? monthYearLabelBuilder;
   final TextStyle? dateTextStyle;
   final CellCalendarPageController? cellCalendarPageController;
 
@@ -136,7 +135,7 @@ class _CalendarPage extends StatelessWidget {
   }) : super(key: key);
 
   final DateTime visiblePageDate;
-  final daysBuilder? daysOfTheWeekBuilder;
+  final DaysBuilder? daysOfTheWeekBuilder;
   final TextStyle? dateTextStyle;
 
   List<DateTime> _getCurrentDays(DateTime dateTime) {

--- a/lib/src/components/days_of_the_week.dart
+++ b/lib/src/components/days_of_the_week.dart
@@ -18,7 +18,7 @@ const List<String> _DaysOfTheWeek = [
 class DaysOfTheWeek extends StatelessWidget {
   DaysOfTheWeek(this.daysOfTheWeekBuilder);
 
-  final daysBuilder? daysOfTheWeekBuilder;
+  final DaysBuilder? daysOfTheWeekBuilder;
 
   Widget defaultLabels(index) {
     return Padding(

--- a/lib/src/components/days_row/measure_size.dart
+++ b/lib/src/components/days_row/measure_size.dart
@@ -20,7 +20,7 @@ class MeasureSize extends StatefulWidget {
 class _MeasureSizeState extends State<MeasureSize> {
   @override
   Widget build(BuildContext context) {
-    SchedulerBinding.instance!.addPostFrameCallback(postFrameCallback);
+    SchedulerBinding.instance.addPostFrameCallback(postFrameCallback);
     return Container(
       key: widgetKey,
       child: widget.child,

--- a/lib/src/components/month_year_label.dart
+++ b/lib/src/components/month_year_label.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../controllers/calendar_state_controller.dart';
-import '../date_extension.dart';
 
 /// Label showing the date of current page
 class MonthYearLabel extends StatelessWidget {
@@ -12,7 +11,7 @@ class MonthYearLabel extends StatelessWidget {
     Key? key,
   }) : super(key: key);
 
-  final monthYearBuilder? monthYearLabelBuilder;
+  final MonthYearBuilder? monthYearLabelBuilder;
 
   @override
   Widget build(BuildContext context) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,35 +21,28 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -66,21 +59,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   nested:
     dependency: transitive
     description:
@@ -94,7 +87,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   provider:
     dependency: "direct main"
     description:
@@ -113,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -134,35 +127,28 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.12"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.16.1 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=2.10.3"


### PR DESCRIPTION
## Issue

This package is losing Pub Points on `pub.dev` not because of bad code but because of leaving elementary warnings.

These warnings cause **annoying** warning message every time one runs an app that uses this package.

## Changes Made

- Change name of variable type defined with `typedef` to correspond with dart-style.
- Remove an unused package import line.
- Remove an unnecessary null check operator (`!`). 