### PR TITLE
Add border customization options (cellBorderColor & cellBorderWidth)

### DIFF
--- a/lib/src/cell_calendar.dart
+++ b/lib/src/cell_calendar.dart
@@ -28,8 +28,7 @@ class CellCalendar extends HookConsumerWidget {
     this.daysOfTheWeekBuilder,
     this.monthYearLabelBuilder,
     this.dateTextStyle,
-    this.cellBorderColor,
-    this.cellBorderWidth = 1.0,
+    this.cellBorderSide,
   });
 
   final CellCalendarPageController? cellCalendarPageController;
@@ -50,15 +49,10 @@ class CellCalendar extends HookConsumerWidget {
   final Color todayMarkColor;
   final Color todayTextColor;
 
-  /// Border color for calendar cells
+  /// Border style for calendar cells
   ///
-  /// If not specified, defaults to [Theme.of(context).dividerColor]
-  final Color? cellBorderColor;
-
-  /// Border width for calendar cells
-  ///
-  /// Defaults to 1.0
-  final double cellBorderWidth;
+  /// If not specified, defaults to `BorderSide(color: Theme.of(context).dividerColor, width: 1)`
+  final BorderSide? cellBorderSide;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -73,8 +67,7 @@ class CellCalendar extends HookConsumerWidget {
         onCellTapped: onCellTapped,
         todayMarkColor: todayMarkColor,
         todayTextColor: todayTextColor,
-        cellBorderColor: cellBorderColor,
-        cellBorderWidth: cellBorderWidth,
+        cellBorderSide: cellBorderSide,
       ),
     );
   }
@@ -92,8 +85,7 @@ class _CalendarPageView extends HookConsumerWidget {
     required this.onCellTapped,
     required this.todayMarkColor,
     required this.todayTextColor,
-    this.cellBorderColor,
-    this.cellBorderWidth = 1.0,
+    this.cellBorderSide,
   }) : super(key: key);
   final CellCalendarPageController? cellCalendarPageController;
 
@@ -112,8 +104,7 @@ class _CalendarPageView extends HookConsumerWidget {
   final void Function(DateTime)? onCellTapped;
   final Color todayMarkColor;
   final Color todayTextColor;
-  final Color? cellBorderColor;
-  final double cellBorderWidth;
+  final BorderSide? cellBorderSide;
 
   DateTime _getFirstDay(DateTime dateTime) {
     final firstDayOfTheMonth = DateTime(dateTime.year, dateTime.month, 1);
@@ -139,8 +130,7 @@ class _CalendarPageView extends HookConsumerWidget {
                 todayMarkColor: todayMarkColor,
                 todayTextColor: todayTextColor,
                 events: events,
-                cellBorderColor: cellBorderColor,
-                cellBorderWidth: cellBorderWidth,
+                cellBorderSide: cellBorderSide,
               );
             },
             onPageChanged: (index) {
@@ -177,8 +167,7 @@ class _CalendarPage extends StatelessWidget {
     required this.todayMarkColor,
     required this.todayTextColor,
     required this.events,
-    this.cellBorderColor,
-    this.cellBorderWidth = 1.0,
+    this.cellBorderSide,
   }) : super(key: key);
 
   final DateTime visiblePageDate;
@@ -188,8 +177,7 @@ class _CalendarPage extends StatelessWidget {
   final Color todayMarkColor;
   final Color todayTextColor;
   final List<CalendarEvent> events;
-  final Color? cellBorderColor;
-  final double cellBorderWidth;
+  final BorderSide? cellBorderSide;
 
   List<DateTime> _getCurrentDays(DateTime dateTime) {
     final List<DateTime> result = [];
@@ -226,8 +214,7 @@ class _CalendarPage extends StatelessWidget {
                   todayMarkColor: todayMarkColor,
                   todayTextColor: todayTextColor,
                   events: events,
-                  cellBorderColor: cellBorderColor,
-                  cellBorderWidth: cellBorderWidth,
+                  cellBorderSide: cellBorderSide,
                 );
               },
             ),

--- a/lib/src/cell_calendar.dart
+++ b/lib/src/cell_calendar.dart
@@ -28,6 +28,8 @@ class CellCalendar extends HookConsumerWidget {
     this.daysOfTheWeekBuilder,
     this.monthYearLabelBuilder,
     this.dateTextStyle,
+    this.cellBorderColor,
+    this.cellBorderWidth = 1.0,
   });
 
   final CellCalendarPageController? cellCalendarPageController;
@@ -48,6 +50,16 @@ class CellCalendar extends HookConsumerWidget {
   final Color todayMarkColor;
   final Color todayTextColor;
 
+  /// Border color for calendar cells
+  ///
+  /// If not specified, defaults to [Theme.of(context).dividerColor]
+  final Color? cellBorderColor;
+
+  /// Border width for calendar cells
+  ///
+  /// Defaults to 1.0
+  final double cellBorderWidth;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return ProviderScope(
@@ -61,6 +73,8 @@ class CellCalendar extends HookConsumerWidget {
         onCellTapped: onCellTapped,
         todayMarkColor: todayMarkColor,
         todayTextColor: todayTextColor,
+        cellBorderColor: cellBorderColor,
+        cellBorderWidth: cellBorderWidth,
       ),
     );
   }
@@ -78,6 +92,8 @@ class _CalendarPageView extends HookConsumerWidget {
     required this.onCellTapped,
     required this.todayMarkColor,
     required this.todayTextColor,
+    this.cellBorderColor,
+    this.cellBorderWidth = 1.0,
   }) : super(key: key);
   final CellCalendarPageController? cellCalendarPageController;
 
@@ -96,6 +112,8 @@ class _CalendarPageView extends HookConsumerWidget {
   final void Function(DateTime)? onCellTapped;
   final Color todayMarkColor;
   final Color todayTextColor;
+  final Color? cellBorderColor;
+  final double cellBorderWidth;
 
   DateTime _getFirstDay(DateTime dateTime) {
     final firstDayOfTheMonth = DateTime(dateTime.year, dateTime.month, 1);
@@ -121,6 +139,8 @@ class _CalendarPageView extends HookConsumerWidget {
                 todayMarkColor: todayMarkColor,
                 todayTextColor: todayTextColor,
                 events: events,
+                cellBorderColor: cellBorderColor,
+                cellBorderWidth: cellBorderWidth,
               );
             },
             onPageChanged: (index) {
@@ -157,6 +177,8 @@ class _CalendarPage extends StatelessWidget {
     required this.todayMarkColor,
     required this.todayTextColor,
     required this.events,
+    this.cellBorderColor,
+    this.cellBorderWidth = 1.0,
   }) : super(key: key);
 
   final DateTime visiblePageDate;
@@ -166,6 +188,8 @@ class _CalendarPage extends StatelessWidget {
   final Color todayMarkColor;
   final Color todayTextColor;
   final List<CalendarEvent> events;
+  final Color? cellBorderColor;
+  final double cellBorderWidth;
 
   List<DateTime> _getCurrentDays(DateTime dateTime) {
     final List<DateTime> result = [];
@@ -202,6 +226,8 @@ class _CalendarPage extends StatelessWidget {
                   todayMarkColor: todayMarkColor,
                   todayTextColor: todayTextColor,
                   events: events,
+                  cellBorderColor: cellBorderColor,
+                  cellBorderWidth: cellBorderWidth,
                 );
               },
             ),

--- a/lib/src/components/days_row/days_row.dart
+++ b/lib/src/components/days_row/days_row.dart
@@ -18,8 +18,7 @@ class DaysRow extends StatelessWidget {
     required this.todayMarkColor,
     required this.todayTextColor,
     required this.events,
-    this.cellBorderColor,
-    this.cellBorderWidth = 1.0,
+    this.cellBorderSide,
   }) : super(key: key);
 
   final List<DateTime> dates;
@@ -29,8 +28,7 @@ class DaysRow extends StatelessWidget {
   final Color todayMarkColor;
   final Color todayTextColor;
   final List<CalendarEvent> events;
-  final Color? cellBorderColor;
-  final double cellBorderWidth;
+  final BorderSide? cellBorderSide;
 
   @override
   Widget build(BuildContext context) {
@@ -45,8 +43,7 @@ class DaysRow extends StatelessWidget {
             todayMarkColor: todayMarkColor,
             todayTextColor: todayTextColor,
             events: events,
-            cellBorderColor: cellBorderColor,
-            cellBorderWidth: cellBorderWidth,
+            cellBorderSide: cellBorderSide,
           );
         }).toList(),
       ),
@@ -66,8 +63,7 @@ class _DayCell extends HookConsumerWidget {
     required this.todayMarkColor,
     required this.todayTextColor,
     required this.events,
-    this.cellBorderColor,
-    this.cellBorderWidth = 1.0,
+    this.cellBorderSide,
   });
 
   final DateTime date;
@@ -77,8 +73,7 @@ class _DayCell extends HookConsumerWidget {
   final Color todayMarkColor;
   final Color todayTextColor;
   final List<CalendarEvent> events;
-  final Color? cellBorderColor;
-  final double cellBorderWidth;
+  final BorderSide? cellBorderSide;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -94,14 +89,10 @@ class _DayCell extends HookConsumerWidget {
         child: DecoratedBox(
           decoration: BoxDecoration(
             border: Border(
-              top: BorderSide(
-                color: cellBorderColor ?? Theme.of(context).dividerColor,
-                width: cellBorderWidth,
-              ),
-              right: BorderSide(
-                color: cellBorderColor ?? Theme.of(context).dividerColor,
-                width: cellBorderWidth,
-              ),
+              top: cellBorderSide ??
+                  BorderSide(color: Theme.of(context).dividerColor, width: 1),
+              right: cellBorderSide ??
+                  BorderSide(color: Theme.of(context).dividerColor, width: 1),
             ),
           ),
           child: MeasureSize(

--- a/lib/src/components/days_row/days_row.dart
+++ b/lib/src/components/days_row/days_row.dart
@@ -18,6 +18,8 @@ class DaysRow extends StatelessWidget {
     required this.todayMarkColor,
     required this.todayTextColor,
     required this.events,
+    this.cellBorderColor,
+    this.cellBorderWidth = 1.0,
   }) : super(key: key);
 
   final List<DateTime> dates;
@@ -27,6 +29,8 @@ class DaysRow extends StatelessWidget {
   final Color todayMarkColor;
   final Color todayTextColor;
   final List<CalendarEvent> events;
+  final Color? cellBorderColor;
+  final double cellBorderWidth;
 
   @override
   Widget build(BuildContext context) {
@@ -41,6 +45,8 @@ class DaysRow extends StatelessWidget {
             todayMarkColor: todayMarkColor,
             todayTextColor: todayTextColor,
             events: events,
+            cellBorderColor: cellBorderColor,
+            cellBorderWidth: cellBorderWidth,
           );
         }).toList(),
       ),
@@ -60,6 +66,8 @@ class _DayCell extends HookConsumerWidget {
     required this.todayMarkColor,
     required this.todayTextColor,
     required this.events,
+    this.cellBorderColor,
+    this.cellBorderWidth = 1.0,
   });
 
   final DateTime date;
@@ -69,6 +77,8 @@ class _DayCell extends HookConsumerWidget {
   final Color todayMarkColor;
   final Color todayTextColor;
   final List<CalendarEvent> events;
+  final Color? cellBorderColor;
+  final double cellBorderWidth;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -84,9 +94,14 @@ class _DayCell extends HookConsumerWidget {
         child: DecoratedBox(
           decoration: BoxDecoration(
             border: Border(
-              top: BorderSide(color: Theme.of(context).dividerColor, width: 1),
-              right:
-                  BorderSide(color: Theme.of(context).dividerColor, width: 1),
+              top: BorderSide(
+                color: cellBorderColor ?? Theme.of(context).dividerColor,
+                width: cellBorderWidth,
+              ),
+              right: BorderSide(
+                color: cellBorderColor ?? Theme.of(context).dividerColor,
+                width: cellBorderWidth,
+              ),
             ),
           ),
           child: MeasureSize(


### PR DESCRIPTION
## Summary
- Add `cellBorderSide` parameter to customize the border style of calendar cells
- If not specified, defaults to `BorderSide(color: Theme.of(context).dividerColor, width: 1)`

## Usage
```dart
CellCalendar(
  cellBorderSide: BorderSide(color: Colors.grey, width: 2.0),
  // ... other parameters
)
```

## Test plan
- [ ] Verify borders render correctly with default values
- [ ] Verify custom BorderSide is applied correctly
- [ ] Verify border styling works across different themes

🤖 Generated with [Claude Code](https://claude.ai/code)